### PR TITLE
FOSFAB-187: Fixing "update" mode and another address import issue

### DIFF
--- a/CRM/Csvimport/Import/Parser/Api.php
+++ b/CRM/Csvimport/Import/Parser/Api.php
@@ -327,7 +327,7 @@ class CRM_Csvimport_Import_Parser_Api extends CRM_Import_Parser {
           }
         }
 
-        if (count($uniqueField) === $fieldCount) {
+        if (!empty($uniqueField) && count($uniqueField) === $fieldCount) {
           $tmp['sequential'] = 1;
           $tmp['return'] = ['id'];
           $existingEntity = civicrm_api3($this->getSubmittedValue('entity'), 'get', $tmp);

--- a/CRM/Csvimport/Import/Parser/Api.php
+++ b/CRM/Csvimport/Import/Parser/Api.php
@@ -349,6 +349,37 @@ class CRM_Csvimport_Import_Parser_Api extends CRM_Import_Parser {
   }
 
   /**
+  * Overridden to allow adding special case to deal with
+  * the Address `country_id` field.
+  *
+  * @param array $values
+   *
+  * @return array
+  */
+  public function getMappedRow(array $values): array {
+    $params = [];
+
+    foreach ($this->getFieldMappings() as $i => $mappedField) {
+      if ($mappedField['name'] === 'do_not_import') {
+        continue;
+      }
+
+      if ($mappedField['name']) {
+        if ($this->_entity == 'Address' && $mappedField['name'] == 'country_id') {
+          //  hack to get the set the correct $params key for the `country_id` field
+          // instead of the incorrect one given by `$this->getFieldMetadata()`.
+          $params['country_id'] = $this->getTransformedFieldValue($mappedField['name'], $values[$i]);
+        }
+        else {
+          $params[$this->getFieldMetadata($mappedField['name'])['name']] = $this->getTransformedFieldValue($mappedField['name'], $values[$i]);
+        }
+      }
+    }
+
+    return $params;
+  }
+
+  /**
    * Set import entity
    *
    * @param string $entity


### PR DESCRIPTION
## Issue 1

Importing data with "Allow Updating An Entity Using Unique Fields" option (update mode) is not working and throws this error:

```
count(): Argument #1 ($value) must be of type Countable|array, null given in CRM_Csvimport_Import_Parser_Api->import() (line 330 of /var/www/default/htdocs/httpdocs/profiles/compuclient/modules/contrib/civicrm/ext/nz.co.fuzion.csvimport/CRM/Csvimport/Import/Parser/Api.php)
```

Which is fixed here by applying this PR: https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport/pull/61 


## Issue 2

Importing addresses with "Country" field throws an error.

It seems that `$this->getFieldMetadata()` returns incorrect result for the country (country_id) field, which is getting called by the 

`CRM_Import_Parser::getMappedRow` in this Paraser/Api.php class in this extension, so instead of relying on the core one I override this method and added a hack to use the `country_id` field name directly instead of using `$this->getFieldMetadata()` .
I opted for this solution because it is much easier and less complicated than trying to get `$this->getFieldMetadata()` returns correct data for the country field, but maybe if we have issues with other fields in the future we can consider a more proper fix.
