### PR TITLE
FOSFAB-155: Apply various patches to fix Membershipextras importer problems

### DIFF
--- a/CRM/Csvimport/Import/Parser/Api.php
+++ b/CRM/Csvimport/Import/Parser/Api.php
@@ -27,6 +27,7 @@ class CRM_Csvimport_Import_Parser_Api extends CRM_Import_Parser {
       'name' => 'csv_api_importer',
       'id' => 'csv_api_importer',
       'title' => 'Api Import',
+      'entity' => 'Unknown',
     ]];
   }
 
@@ -36,9 +37,13 @@ class CRM_Csvimport_Import_Parser_Api extends CRM_Import_Parser {
   public function setFieldMetadata(): void {
     $this->importableFieldsMetadata = array_merge(
       ['' => ['title' => ts('- do not import -')]],
-      civicrm_api3($this->_entity, 'getfields', ['action' => 'create'])['values']
+      civicrm_api3($this->getEntity(), 'getfields', ['action' => 'create'])['values']
     );
     foreach ($this->importableFieldsMetadata as $field => $values) {
+      if (empty($values['entity'])) {
+        $this->importableFieldsMetadata[$field]['entity'] = $this->getEntity();
+      }
+
       if (empty($values['title']) && !empty($values['label'])) {
         $this->importableFieldsMetadata[$field]['title'] = $values['label'];
       }
@@ -386,6 +391,16 @@ class CRM_Csvimport_Import_Parser_Api extends CRM_Import_Parser {
    */
   public function setEntity(string $entity): void {
     $this->_entity = $entity;
+  }
+
+
+  /**
+  * Get the entity being imported.
+  *
+  * @return string
+  */
+  public function getEntity(): string {
+    return $this->getSubmittedValue('entity');
   }
 
   /**


### PR DESCRIPTION
## Overview

This applies the following patches:

- https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport/commit/a7ea7a7ab5b15f7e54cf96bec3432e820930dbcd
- https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport/commit/78c3074e59154171565d15b9911cb82db0c42cec
- https://github.com/eileenmcnaughton/nz.co.fuzion.csvimport/commit/1957b45222dec0c9926eea585d53b4d9a69ceec5

that solves the following errors when trying to import using the custom `MembershipextrasImporter` API:

```
http://localhost:3952/civicrm/queue/ajax/runNext|http://localhost:3952/civicrm/queue/runner?reset=1&qrid=user_job_67|1||TypeError: Civi\API\Request::create():
 Argument #1 ($entity) must be of type string, null given, called in /var/www/default/htdocs/httpdocs/profiles/compuclient/modules/contrib/civicrm/api/api.php on line 
71 in Civi\API\Request::create() (line 35 of /var/www/default/htdocs/httpdocs/profiles/compuclient/modules/contrib/civicrm/Civi/API/Request.php).
```

&

```
http://localhost:3952
|php|http://fosfa.localhost:3952/civicrm/queue/ajax/runNext|http://localhost:3952/civicrm/queue/runner?reset=1&qrid=user_job_67|1||TypeError:
 CRM_Import_Parser::getFieldMetadata(): Return value must be of type array, null returned in CRM_Import_Parser->getFieldMetadata() 
 (line 1504 of /var/www/default/htdocs/httpdocs/profiles/compuclient/modules/contrib
```


hence that the solution in this PR is not enough, and that I also needed to create this PR:

https://github.com/compucorp/uk.co.compucorp.membershipextrasimporterapi/pull/30

on the MembershipextrasImporter extension for it to work with the CSV importer.
